### PR TITLE
Update sbt and migrate publishing to GitLab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea/
+.bsp/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A small library to represent transaction demarcation and propagation programmati
 ## Installation
 
 ```
-resolvers += Resolver.url("Agilogy Scala",url("http://dl.bintray.com/agilogy/scala/"))(Resolver.ivyStylePatterns)
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
 
 libraryDependencies += "com.agilogy" %% "srdb-tx" % "1.1"
 ```
@@ -19,6 +19,14 @@ libraryDependencies += "com.agilogy" %% "srdb-tx" % "1.1"
 ## Usage
 
 TO-DO
+
+## Publishing
+
+To publish this package to Agilogy's Package Registry, set the `GITLAB_DEPLOY_TOKEN` environment variable and then run the following command in sbt:
+
+```
+sbt:simple-db> +publish
+```
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A small library to represent transaction demarcation and propagation programmati
 ## Installation
 
 ```
-resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/-/packages/maven"
 
-libraryDependencies += "com.agilogy" %% "srdb-tx" % "1.1"
+libraryDependencies += "com.agilogy" %% "srdb-tx" % "1.2"
 ```
 
 ## Usage
@@ -25,7 +25,7 @@ TO-DO
 To publish this package to Agilogy's Package Registry, set the `GITLAB_DEPLOY_TOKEN` environment variable and then run the following command in sbt:
 
 ```
-sbt:simple-db> +publish
+sbt:srdb-tx> +publish
 ```
 
 ## Copyright

--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,11 @@ organization := "com.agilogy"
 
 name := "srdb-tx"
 
-version := "1.1"
+version := "1.2"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.13"
 
-crossScalaVersions := Seq("2.11.7","2.12.6")
+crossScalaVersions := Seq("2.11.7","2.12.13")
 
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc41" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import _root_.wartremover.WartRemover.autoImport._
-import bintray.Keys._
 import com.typesafe.sbt.SbtScalariform._
 import org.scalastyle.sbt.ScalastylePlugin._
+import com.gilcloud.sbt.gitlab.{GitlabCredentials,GitlabPlugin}
 
 organization := "com.agilogy"
 
@@ -11,7 +11,7 @@ version := "1.1"
 
 scalaVersion := "2.12.6"
 
-crossScalaVersions := Seq("2.10.6", "2.11.7","2.12.6")
+crossScalaVersions := Seq("2.11.7","2.12.6")
 
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc41" % "test",
@@ -77,22 +77,20 @@ scalastyleFailOnError := true
 
 // <-- Linters
 
-// Reformat at every compile.
-// See https://github.com/sbt/sbt-scalariform
-scalariformSettings
+// --> gitlab
 
-publishMavenStyle := false
+GitlabPlugin.autoImport.gitlabGroupId := None
+GitlabPlugin.autoImport.gitlabProjectId := Some(26236490)
+GitlabPlugin.autoImport.gitlabDomain := "gitlab.com"
 
-// --> bintray
+GitlabPlugin.autoImport.gitlabCredentials := {
+    val token = sys.env.get("GITLAB_DEPLOY_TOKEN") match {
+        case Some(token) => token
+        case None =>
+            sLog.value.warn(s"Environment variable GITLAB_DEPLOY_TOKEN is undefined, 'publish' will fail.")
+            ""
+    }
+    Some(GitlabCredentials("Deploy-Token", token))
+}
 
-seq(bintrayPublishSettings: _*)
-
-repository in bintray := "scala"
-
-bintrayOrganization in bintray := Some("agilogy")
-
-packageLabels in bintray := Seq("scala")
-
-licenses +=("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-
-// <-- bintray
+// <-- gitlab

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,6 +1,0 @@
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-    Resolver.ivyStylePatterns)
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,8 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
+
+addSbtPlugin("com.gilcloud" % "sbt-gitlab" % "0.0.6")


### PR DESCRIPTION
Bintray is shutting down on May 1st, so we are moving to a different platform.
Packages for `srdb-tx` are already published on [Agilogy's Package Registry](https://gitlab.com/groups/agilogy/-/packages) on GitLab.